### PR TITLE
basic outline of a with Auth filter

### DIFF
--- a/examples/basic_auth.rs
+++ b/examples/basic_auth.rs
@@ -1,0 +1,50 @@
+#![deny(warnings)]
+
+use warp::Filter;
+use warp::auth::{basic, Authorizer};
+use headers::authorization::Basic;
+
+use std::{collections::HashMap, sync::{Arc, RwLock}};
+
+struct Auth {
+    users: Arc<RwLock<HashMap<&'static str, &'static str>>>,
+}
+
+impl Authorizer for Auth {
+    fn basic(&self, basic: &Basic) -> Result<(), ()> {
+        let lock = self.users.read().map_err(|_e| {
+            println!("Locked RwLock from same thread twice....");
+        })?;
+        if let Some(pw) = lock.get(basic.username()) {
+            if *pw == basic.password() {
+                return Ok(())
+            }
+        }
+        Err(())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+    let mut users = HashMap::new();
+    users.insert("PersonOne", "CorrectHorseBatteryStaple");
+    users.insert("PersonTwo", "Hunter2");
+    let users = Arc::new(RwLock::new(users));
+    let auth = Auth {
+        users
+    };
+    let readme = warp::any()
+        .and(warp::path::end())
+        .and(warp::fs::file("./README.md"));
+    
+
+    // These files will only be available with a valid auth header
+    let secret_examples = warp::path("ex").and(warp::fs::dir("./examples/")).with(basic("MyRealm", auth));
+
+    // GET / => README.md
+    // GET /ex/... => ./examples/..
+    let routes = readme.or(secret_examples);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/examples/basic_auth.rs
+++ b/examples/basic_auth.rs
@@ -1,10 +1,13 @@
 #![deny(warnings)]
 
-use warp::Filter;
-use warp::auth::{basic, Authorizer};
 use headers::authorization::Basic;
+use warp::auth::{basic, Authorizer};
+use warp::Filter;
 
-use std::{collections::HashMap, sync::{Arc, RwLock}};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 struct Auth {
     users: Arc<RwLock<HashMap<&'static str, &'static str>>>,
@@ -17,7 +20,7 @@ impl Authorizer for Auth {
         })?;
         if let Some(pw) = lock.get(basic.username()) {
             if *pw == basic.password() {
-                return Ok(())
+                return Ok(());
             }
         }
         Err(())
@@ -31,16 +34,15 @@ async fn main() {
     users.insert("PersonOne", "CorrectHorseBatteryStaple");
     users.insert("PersonTwo", "Hunter2");
     let users = Arc::new(RwLock::new(users));
-    let auth = Auth {
-        users
-    };
+    let auth = Auth { users };
     let readme = warp::any()
         .and(warp::path::end())
         .and(warp::fs::file("./README.md"));
-    
 
     // These files will only be available with a valid auth header
-    let secret_examples = warp::path("ex").and(warp::fs::dir("./examples/")).with(basic("MyRealm", auth));
+    let secret_examples = warp::path("ex")
+        .and(warp::fs::dir("./examples/"))
+        .with(basic("MyRealm", auth));
 
     // GET / => README.md
     // GET /ex/... => ./examples/..

--- a/src/filters/auth.rs
+++ b/src/filters/auth.rs
@@ -1,0 +1,230 @@
+//! Auth Filters
+use std::sync::Arc;
+
+use headers::{authorization::Basic, authorization::Bearer};
+
+use crate::{Filter, Rejection, Reply, filter::WrapSealed, reject::CombineRejection};
+use internal::AuthFilter;
+
+/// Wrap routes with basic authentication
+pub fn basic<A: Authorizer+'static>(realm: &'static str, authorizer: A) -> Authed {
+    auth("Basic", realm, authorizer)
+}
+
+/// Wrap routes with bearer authentication
+pub fn bearer<A: Authorizer+'static>(realm: &'static str, authorizer: A) -> Authed {
+    auth("Bearer", realm, authorizer)
+}
+
+/// Authentication middleware
+pub fn auth<A: Authorizer+'static>(scheme: &'static str, realm: &'static str, authorizer: A) -> Authed {
+    Authed {
+        scheme,
+        realm,
+        authorizer: Arc::new(authorizer),
+    }
+}
+
+impl<F> WrapSealed<F> for Authed
+where
+    F: Filter + Clone + Send + Sync + 'static,
+    F::Extract: Reply,
+    F::Error: CombineRejection<Rejection>,
+    <F::Error as CombineRejection<Rejection>>::One: CombineRejection<Rejection>,
+{
+    type Wrapped = AuthFilter<F>;
+
+    fn wrap(&self, inner: F) -> Self::Wrapped {
+        
+
+        AuthFilter { inner, authorizer: self.authorizer.clone(), scheme: self.scheme, realm: self.realm }
+    }
+}
+
+/// Authentication middleware
+pub struct Authed {
+    scheme: &'static str,
+    realm: &'static str,
+    authorizer: Arc<dyn Authorizer>,
+}
+
+impl std::fmt::Debug for Authed {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Authed")
+            .finish()
+    }
+}
+
+/// Authentication Challenge Rejection
+#[derive(Debug)]
+pub struct Challenge {
+    /// Authentication scheme
+    ///
+    /// Currently Supported
+    /// - Basic
+    /// - Bearer
+    pub scheme: &'static str,
+    /// Authentication realm, this value will be provided
+    /// in the WWW-Authenticate header
+    pub realm: &'static str,
+}
+
+impl std::fmt::Display for Challenge {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} Challenge for realm {}", self.scheme, self.realm)
+    }
+}
+
+/// A trait that defines user authorization
+pub trait Authorizer: Send + Sync {
+    /// Authorize this request's bearer token
+    fn bearer(&self, _cred: &Bearer) -> Result<(), ()> {
+        Err(())
+    }
+    /// Authorize this request's basic credentials
+    fn basic(&self, _cred: &Basic) -> Result<(), ()> {
+        Err(())
+    }
+}
+
+mod internal {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    use futures::{future, ready, TryFuture};
+    use headers::{Authorization, HeaderValue, authorization::{Basic, Bearer}};
+    use pin_project::pin_project;
+
+    use crate::filter::{Filter, FilterBase, Internal, One};
+    use crate::reject::{CombineRejection, Rejection};
+    use crate::route;
+
+    use super::Authorizer;
+
+    #[derive(Clone)]
+    pub struct AuthFilter<F> {
+        pub(super) authorizer: Arc<dyn Authorizer>,
+        pub(super) scheme: &'static str,
+        pub(super) realm: &'static str,
+        pub(super) inner: F,
+    }
+    impl<F> std::fmt::Debug for AuthFilter<F> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_struct("AuthFilter")
+                .field("scheme", &self.scheme)
+                .field("realm", &self.realm)
+                .finish()
+        }
+    }
+    impl<F> FilterBase for AuthFilter<F>
+    where
+        F: Filter,
+        F::Extract: Send,
+        F::Future: Future,
+        F::Error: CombineRejection<Rejection>,
+    {
+        type Extract = One<Wrapped<F::Extract>>;
+        type Error = <F::Error as CombineRejection<Rejection>>::One;
+        type Future = future::Either<future::Ready<Result<Self::Extract, Self::Error>>, WrappedFuture<F::Future>>;
+
+        fn filter(&self, _: Internal) -> Self::Future {
+            use headers::HeaderMapExt;
+            let validated = route::with(|route| {
+                    let hv = route.headers().get(http::header::AUTHORIZATION).cloned();
+                    if let Ok(Some(header)) = route.headers().typed_try_get::<Authorization<Basic>>() {
+                        Some((self.authorizer.basic(&header.0), hv))
+                    } else if let Ok(Some(header)) = route.headers().typed_try_get::<Authorization<Bearer>>() {
+                        Some((self.authorizer.bearer(&header.0), hv))
+                    } else {
+                        None
+                    }
+                });
+            match validated {
+                Some((Ok(_), auth)) => {
+                    let wrapped = WrappedFuture {
+                        inner: self.inner.filter(Internal),
+                        wrapped: (self.authorizer.clone(), auth.unwrap().clone())
+                    };
+                    future::Either::Right(wrapped)
+                },
+                Some((Err(_), _)) => {
+                    let rejection = crate::reject::forbidden();
+                    future::Either::Left(future::err(rejection.into()))
+                }
+                None => {
+                    let rejection = crate::reject::unauthorized_challenge(self.scheme, self.realm);
+                    future::Either::Left(future::err(rejection.into()))
+                }
+            }
+        }
+    }
+    pub struct Wrapped<R> {
+        authorizer: Arc<dyn Authorizer>,
+        inner: R,
+        header: HeaderValue,
+    }
+
+    impl<F> std::fmt::Debug for Wrapped<F> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_struct("Wrapped")
+                .field("header", &self.header)
+                .finish()
+        }
+    }
+
+    impl<R> crate::reply::Reply for Wrapped<R>
+    where
+        R: crate::reply::Reply,
+    {
+        fn into_response(self) -> crate::reply::Response {
+            self.inner.into_response()
+        }
+    }
+
+    #[pin_project]
+    pub struct WrappedFuture<F> {
+        #[pin]
+        inner: F,
+        wrapped: (Arc<dyn Authorizer>, HeaderValue),
+    }
+
+    impl<F> std::fmt::Debug for WrappedFuture<F> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_struct("WrappedFuture")
+                .field("header", &self.wrapped.1)
+                .finish()
+        }
+    }
+
+    impl<F> Future for WrappedFuture<F>
+    where
+        F: TryFuture,
+        F::Error: CombineRejection<Rejection>, 
+    {
+        type Output = Result<
+            One<Wrapped<F::Ok>>,
+            <F::Error as CombineRejection<Rejection>>::One,
+        >;
+        
+        
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let pin = self.project();
+            match ready!(pin.inner.try_poll(cx)) {
+                Ok(inner) => {
+                    let (authorizer, header) = pin.wrapped;
+                    let item = (Wrapped {
+                        authorizer: authorizer.clone(),
+                        inner,
+                        header: header.clone(),
+                    },);
+                    
+                    Poll::Ready(Ok(item))
+                }
+                Err(err) => Poll::Ready(Err(err.into())),
+            }
+        }
+    }
+}

--- a/src/filters/auth.rs
+++ b/src/filters/auth.rs
@@ -2,49 +2,59 @@
 use std::sync::Arc;
 
 use futures::Future;
-use headers::{authorization::Basic, authorization::Bearer};
+use headers::{Authorization, HeaderMap, HeaderMapExt, authorization::Basic, authorization::Bearer};
 
-use crate::{filter::WrapSealed, reject::CombineRejection, Filter, Rejection, Reply};
+use crate::{Filter, Rejection, Reply, filter::WrapSealed, reject::CombineRejection};
 use internal::AuthFilter;
 
 
 
 /// Wrap routes with basic authentication
-pub fn basic<T: Future<Output = Result<(), ()>>, A: Authorizer<T> + 'static>(realm: &'static str, authorizer: A) -> Authed<T> {
-    auth("Basic", realm, authorizer)
+pub fn basic<F, A>(realm: &'static str, f: F) -> Authed<A> 
+where F: Clone + 'static + Fn(AuthHeader) -> A + Send + Sync,
+    A: Future<Output = Result<(), Rejection>> + Send + Sync, {
+    auth("Basic", realm, f)
 }
 
-/// Wrap routes with bearer authentication
-pub fn bearer<T: Future<Output = Result<(), ()>>, A: Authorizer<T> + 'static>(realm: &'static str, authorizer: A) -> Authed<T> {
-    auth("Bearer", realm, authorizer)
-}
+// /// Wrap routes with bearer authentication
+// pub fn bearer<T: Future<Output = Result<(), ()>>, A: Authorizer<T> + 'static>(realm: &'static str, authorizer: A) -> Authed<T> {
+//     auth("Bearer", realm, authorizer)
+// }
 
 /// Authentication middleware
-pub fn auth<T: Future<Output = Result<(), ()>>, A: Authorizer<T> + 'static>(
+pub fn auth<F, A>(
     scheme: &'static str,
     realm: &'static str,
-    authorizer: A,
-) -> Authed<T> {
+    authorizer: F,
+) -> Authed<A> 
+where F: 'static + Fn(AuthHeader) -> A + Send + Sync,
+A: Future<Output = Result<(), Rejection>> + Send + Sync, {
+    let authorizer = Authorizer {
+        scheme,
+        realm,
+        handler: Arc::new(authorizer)
+    };
     Authed {
         scheme,
         realm,
-        authorizer: Arc::new(authorizer),
+        authorizer: authorizer,
     }
 }
 
 impl<F, A> WrapSealed<F> for Authed<A>
 where
     F: Filter + Clone + Send + Sync + 'static,
-    F::Extract: Reply,
+    F::Extract: Reply + Send,
     F::Error: CombineRejection<Rejection>,
     <F::Error as CombineRejection<Rejection>>::One: CombineRejection<Rejection>,
+    A: Future<Output = Result<(), Rejection>> + Clone + Send,
 {
     type Wrapped = AuthFilter<F, A>;
 
     fn wrap(&self, inner: F) -> Self::Wrapped {
         AuthFilter {
             inner,
-            authorizer: self.authorizer.clone(),
+            authorizer: Arc::new(self.authorizer.clone()),
             scheme: self.scheme,
             realm: self.realm,
         }
@@ -52,13 +62,13 @@ where
 }
 
 /// Authentication middleware
-pub struct Authed<F> {
+pub struct Authed<A> {
     scheme: &'static str,
     realm: &'static str,
-    authorizer: Arc<dyn Authorizer<F>>,
+    authorizer: Authorizer<A>,
 }
 
-impl<F> std::fmt::Debug for Authed<F> {
+impl<A> std::fmt::Debug for Authed<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Authed").finish()
     }
@@ -84,17 +94,46 @@ impl std::fmt::Display for Challenge {
     }
 }
 
-/// A trait that defines user authorization
-pub trait Authorizer<F>: Send + Sync 
-where F: Future<Output = Result<(), ()>>, {
-    /// Authorize this request's bearer token
-    fn bearer(&self, _cred: &Bearer) -> F {
-        futures::future::err(())
+/// Authorization handler
+#[derive(Clone)]
+pub struct Authorizer<A> {
+    scheme: &'static str,
+    realm: &'static str,
+    handler: Arc<dyn Fn(AuthHeader) -> A + 'static + Send + Sync>,
+}
+
+impl<A> std::fmt::Debug for Authorizer<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Authorizer").field("scheme", &self.scheme)
+            .field("realm", &self.realm)
+            .finish()
     }
-    /// Authorize this request's basic credentials
-    fn basic(&self, _cred: &Basic) -> F {
-        futures::future::err(())
+}
+
+impl<A> Authorizer<A> 
+where A: Future<Output = Result<(), Rejection>>, {
+    
+    fn handle_request(&self, header: AuthHeader) -> A {
+        (self.handler)(header)
     }
+
+    fn extract_header(&self, headers: &HeaderMap) -> Option<AuthHeader> {
+        if let Ok(Some(header)) = headers.typed_try_get::<Authorization<Basic>>() {
+            Some(AuthHeader::Basic(header.0))
+        } else if let Ok(Some(header)) = headers.typed_try_get::<Authorization<Bearer>>() {
+            Some(AuthHeader::Bearer(header.0))
+        } else {
+            None
+        }
+    }
+}
+/// Authorization Header's inner value
+#[derive(Clone, PartialEq, Debug)]
+pub enum AuthHeader {
+    /// Basic Authentication header 
+    Basic(Basic),
+    /// Bearer Authentication header
+    Bearer(Bearer),
 }
 
 mod internal {
@@ -103,22 +142,19 @@ mod internal {
     use std::sync::Arc;
     use std::task::{Context, Poll};
 
-    use futures::{future, ready, TryFuture};
-    use headers::{
-        authorization::{Basic, Bearer},
-        Authorization, HeaderValue,
-    };
+    use futures::{TryFuture, future, ready};
+    
     use pin_project::pin_project;
 
     use crate::filter::{Filter, FilterBase, Internal, One};
     use crate::reject::{CombineRejection, Rejection};
     use crate::route;
 
-    use super::Authorizer;
+    use super::{Authorizer, AuthHeader};
 
     #[derive(Clone)]
     pub struct AuthFilter<F, A> {
-        pub(super) authorizer: Arc<dyn Authorizer<A>>,
+        pub(super) authorizer: Arc<Authorizer<A>>,
         pub(super) scheme: &'static str,
         pub(super) realm: &'static str,
         pub(super) inner: F,
@@ -131,45 +167,36 @@ mod internal {
                 .finish()
         }
     }
+    
+
     impl<F, A> FilterBase for AuthFilter<F, A>
     where
-        F: Filter,
+        F: Filter + Send,
         F::Extract: Send,
         F::Future: Future,
         F::Error: CombineRejection<Rejection>,
+        A: Send + Sync + Future<Output = Result<(), Rejection>>,
     {
-        type Extract = One<Wrapped<F::Extract, A>>;
+        type Extract =
+            One<crate::generic::Either<One<WrappedPendingFuture<F::Extract, A>>, F::Extract>>;
         type Error = <F::Error as CombineRejection<Rejection>>::One;
         type Future = future::Either<
             future::Ready<Result<Self::Extract, Self::Error>>,
-            WrappedFuture<F::Future, A>,
+            WrappedPendingFuture<F, A>,
         >;
 
         fn filter(&self, _: Internal) -> Self::Future {
-            use headers::HeaderMapExt;
-            let validated = route::with(|route| {
-                let hv = route.headers().get(http::header::AUTHORIZATION).cloned();
-                if let Ok(Some(header)) = route.headers().typed_try_get::<Authorization<Basic>>() {
-                    Some((self.authorizer.basic(&header.0), hv))
-                } else if let Ok(Some(header)) =
-                    route.headers().typed_try_get::<Authorization<Bearer>>()
-                {
-                    Some((self.authorizer.bearer(&header.0), hv))
-                } else {
-                    None
-                }
+            let header = route::with(|route| {
+                self.authorizer.extract_header(route.headers())
             });
-            match validated {
-                Some((Ok(_), auth)) => {
-                    let wrapped = WrappedFuture {
-                        inner: self.inner.filter(Internal),
-                        wrapped: (self.authorizer.clone(), auth.unwrap().clone()),
-                    };
-                    future::Either::Right(wrapped)
-                }
-                Some((Err(_), _)) => {
-                    let rejection = crate::reject::forbidden();
-                    future::Either::Left(future::err(rejection.into()))
+            match header {
+                Some(header) => {
+                    future::Either::Right(
+                    WrappedPendingFuture {
+                        inner: self.inner,
+                        auth: self.authorizer.handle_request(header),
+                        wrapped: (self.authorizer.clone(), header),
+                    })
                 }
                 None => {
                     let rejection = crate::reject::unauthorized_challenge(self.scheme, self.realm);
@@ -178,16 +205,14 @@ mod internal {
             }
         }
     }
-    pub struct Wrapped<R, A> {
-        authorizer: Arc<dyn Authorizer<A>>,
-        inner: R,
-        header: HeaderValue,
+    pub struct Wrapped<F, A> {
+        wrapped: (Arc<Authorizer<A>>, AuthHeader),
+        inner: F,
     }
 
     impl<F, A> std::fmt::Debug for Wrapped<F, A> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             f.debug_struct("Wrapped")
-                .field("header", &self.header)
                 .finish()
         }
     }
@@ -202,21 +227,62 @@ mod internal {
     }
 
     #[pin_project]
-    pub struct WrappedFuture<F, A> {
+    pub struct WrappedPendingFuture<F, A> {
         #[pin]
         inner: F,
-        wrapped: (Arc<dyn Authorizer<A>>, HeaderValue),
+        #[pin]
+        auth: A,
+        wrapped: (Arc<Authorizer<A>>, AuthHeader),
     }
 
-    impl<F, A> std::fmt::Debug for WrappedFuture<F, A> {
+    impl<F, A> std::fmt::Debug for WrappedPendingFuture<F, A> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.debug_struct("WrappedFuture")
-                .field("header", &self.wrapped.1)
+            f.debug_struct("WrappedPendingFuture")
                 .finish()
         }
     }
 
-    impl<F, A> Future for WrappedFuture<F, A>
+    impl<A, F> Future for WrappedPendingFuture<F, A>
+    where
+        F: Filter,
+        F::Extract: Send,
+        F::Future: Future,
+        F::Error: CombineRejection<Rejection>,
+        A: TryFuture,
+        A::Error: CombineRejection<Rejection>,
+    {
+        type Output = Result<One<WrappedAuthedFuture<F::Future, A>>, <A::Error as CombineRejection<Rejection>>::One>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let pin = self.project();
+            match ready!(pin.auth.try_poll(cx)) {
+                Ok(_) => {
+                    let (authorizer, header) = pin.wrapped;
+                    let item = (WrappedAuthedFuture {
+                        wrapped: (authorizer.clone(), header.clone()),
+                        inner: pin.inner.filter(Internal),
+                    },);
+                    Poll::Ready(Ok(item))
+                }
+                Err(err) => Poll::Ready(Err(crate::reject::forbidden().into())),
+            }
+        }
+    }
+    #[pin_project]
+    pub struct WrappedAuthedFuture<F, A> {
+        #[pin]
+        inner: F,
+        wrapped: (Arc<Authorizer<A>>, AuthHeader),
+    }
+
+    impl<F, A> std::fmt::Debug for WrappedAuthedFuture<F, A> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_struct("WrappedAuthedFuture")
+                .finish()
+        }
+    }
+
+    impl<A, F> Future for WrappedAuthedFuture<F, A>
     where
         F: TryFuture,
         F::Error: CombineRejection<Rejection>,
@@ -229,11 +295,9 @@ mod internal {
                 Ok(inner) => {
                     let (authorizer, header) = pin.wrapped;
                     let item = (Wrapped {
-                        authorizer: authorizer.clone(),
-                        inner,
-                        header: header.clone(),
+                        wrapped: (authorizer.clone(), header.clone()),
+                        inner: inner,
                     },);
-
                     Poll::Ready(Ok(item))
                 }
                 Err(err) => Poll::Ready(Err(err.into())),

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod addr;
 pub mod any;
+pub mod auth;
 pub mod body;
 #[cfg(feature = "compression")]
 pub mod compression;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub use self::filters::{
     addr,
     // any() function
     any::any,
+    auth,
     body,
     cookie,
     // cookie() function

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -433,14 +433,16 @@ impl Rejections {
 
     fn into_response(&self) -> crate::reply::Response {
         match self {
-            Rejections::Known(Known::Unauthorized(crate::filters::auth::Challenge { realm, scheme})) => {
+            Rejections::Known(Known::Unauthorized(crate::filters::auth::Challenge {
+                realm,
+                scheme,
+            })) => {
                 let mut res = http::Response::new(Body::from("Unauthorized".to_string()));
                 *res.status_mut() = self.status();
-                if let Ok(realm_header) = HeaderValue::from_str(&format!(r#"{} realm="{}""#, scheme, realm)) {
-                    res.headers_mut().insert(
-                        WWW_AUTHENTICATE,
-                        realm_header,
-                    );
+                if let Ok(realm_header) =
+                    HeaderValue::from_str(&format!(r#"{} realm="{}""#, scheme, realm))
+                {
+                    res.headers_mut().insert(WWW_AUTHENTICATE, realm_header);
                 } else {
                     *res.status_mut() = StatusCode::FORBIDDEN;
                 }


### PR DESCRIPTION
This is a very basic outline of what a possible `with` filter might look like for authorization. 

Primarily this is a copy of `src/filters/cors.rs` modified enough to make authorization work at a somewhat rudimentary level.

A few things that I am not _super_ happy with but do not know the ideal way to solve. 

- Export of the trait `Authorizer`, this is not something that is done anywhere else in the project so doesn't feel like the right path forward.
- Whatever structure is setup moving forward should probably be returning a `Future` instead of a `Result`, especially not a `Result<(), ()>`
- As noted by the CI failures, my understanding of what is required when wrapping isn't as great as it could be.

